### PR TITLE
GVM xAPI spec fixes

### DIFF
--- a/classes/log/store.php
+++ b/classes/log/store.php
@@ -68,6 +68,9 @@ class store extends php_obj implements log_writer {
      */
     protected function insert_event_entries(array $events) {
         global $DB;
+		
+		//don't log any events without a definitive user id (an actor) GVM 10-02-21
+		$events = array_filter($events,function($event) { return !empty($event['userid']); });
 
         // If in background mode, just save them in the database.
         if ($this->get_config('backgroundmode', false)) {

--- a/src/loader/lrs.php
+++ b/src/loader/lrs.php
@@ -27,30 +27,34 @@ function load(array $config, array $events) {
 
         $url = utils\correct_endpoint($endpoint).'/statements';
         $auth = base64_encode($username.':'.$password);
-        $postdata = json_encode($statements);
+        
+		
+		if(count($statements) > 0) {
+			$postdata = json_encode($statements);
 
-        if ($postdata === false) {
-            throw new \Exception('JSON encode error: '.json_last_error_msg());
-        }
+			if ($postdata === false) {
+				throw new \Exception('JSON encode error: '.json_last_error_msg());
+			}
 
-        $request = curl_init();
-        curl_setopt($request, CURLOPT_URL, $url);
-        curl_setopt($request, CURLOPT_POSTFIELDS, $postdata);
-        curl_setopt($request, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($request, CURLOPT_SSL_VERIFYPEER, false);
-        curl_setopt($request, CURLOPT_HTTPHEADER, [
-            'Authorization: Basic '.$auth,
-            'X-Experience-API-Version: 1.0.0',
-            'Content-Type: application/json',
-        ]);
+			$request = curl_init();
+			curl_setopt($request, CURLOPT_URL, $url);
+			curl_setopt($request, CURLOPT_POSTFIELDS, $postdata);
+			curl_setopt($request, CURLOPT_RETURNTRANSFER, true);
+			curl_setopt($request, CURLOPT_SSL_VERIFYPEER, false);
+			curl_setopt($request, CURLOPT_HTTPHEADER, [
+				'Authorization: Basic '.$auth,
+				'X-Experience-API-Version: 1.0.0',
+				'Content-Type: application/json',
+			]);
 
-        $responsetext = curl_exec($request);
-        $responsecode = curl_getinfo($request, CURLINFO_RESPONSE_CODE);
-        curl_close($request);
+			$responsetext = curl_exec($request);
+			$responsecode = curl_getinfo($request, CURLINFO_RESPONSE_CODE);
+			curl_close($request);
 
-        if ($responsecode !== 200) {
-            throw new \Exception($responsetext, $responsecode);
-        }
+			if ($responsecode !== 200) {
+				throw new \Exception($responsetext, $responsecode);
+			}
+		}
     };
     return utils\load_in_batches($config, $events, $sendhttpstatements);
 }

--- a/src/loader/moodle_curl_lrs.php
+++ b/src/loader/moodle_curl_lrs.php
@@ -33,25 +33,29 @@ function load(array $config, array $events) {
 
         $url = utils\correct_endpoint($endpoint).'/statements';
         $auth = base64_encode($username.':'.$password);
-        $postdata = json_encode($statements);
+		
+		//don't send empty statement arrays GVM 25-01-21
+        if(count($statements) > 0) {
+			$postdata = json_encode($statements);
 
-        if ($postdata === false) {
-            throw new \Exception('JSON encode error: '.json_last_error_msg());
-        }
+			if ($postdata === false) {
+				throw new \Exception('JSON encode error: '.json_last_error_msg());
+			}
 
-        $request = new \curl();
-        $responsetext = $request->post($url, $postdata, [
-            'CURLOPT_HTTPHEADER' => [
-                'Authorization: Basic '.$auth,
-                'X-Experience-API-Version: 1.0.0',
-                'Content-Type: application/json',
-            ],
-        ]);
-        $responsecode = $request->info['http_code'];
+			$request = new \curl();
+			$responsetext = $request->post($url, $postdata, [
+				'CURLOPT_HTTPHEADER' => [
+					'Authorization: Basic '.$auth,
+					'X-Experience-API-Version: 1.0.0',
+					'Content-Type: application/json',
+				],
+			]);
+			$responsecode = $request->info['http_code'];
 
-        if ($responsecode !== 200) {
-            throw new \Exception($responsetext, $responsecode);
-        }
+			if ($responsecode !== 200) {
+				throw new \Exception($responsetext, $responsecode);
+			}
+		}
     };
     return utils\load_in_batches($config, $events, $sendhttpstatements);
 }

--- a/src/transformer/events/mod_feedback/item_answered/textarea.php
+++ b/src/transformer/events/mod_feedback/item_answered/textarea.php
@@ -47,7 +47,7 @@ function textarea(array $config, \stdClass $event, \stdClass $feedbackvalue, \st
         ],
         'timestamp' => utils\get_event_timestamp($event),
         'result' => [
-            'response' => ($feedbackvalue->value ? $feedbackvalue->value:''),
+            'response' => ($feedbackvalue->value ?: ''),
             'completion' => $feedbackvalue->value !== '',
         ],
         'context' => [

--- a/src/transformer/events/mod_feedback/item_answered/textarea.php
+++ b/src/transformer/events/mod_feedback/item_answered/textarea.php
@@ -47,7 +47,7 @@ function textarea(array $config, \stdClass $event, \stdClass $feedbackvalue, \st
         ],
         'timestamp' => utils\get_event_timestamp($event),
         'result' => [
-            'response' => $feedbackvalue->value,
+            'response' => ($feedbackvalue->value ? $feedbackvalue->value:''),
             'completion' => $feedbackvalue->value !== '',
         ],
         'context' => [

--- a/src/transformer/events/mod_feedback/item_answered/textfield.php
+++ b/src/transformer/events/mod_feedback/item_answered/textfield.php
@@ -47,7 +47,7 @@ function textfield(array $config, \stdClass $event, \stdClass $feedbackvalue, \s
         ],
         'timestamp' => utils\get_event_timestamp($event),
         'result' => [
-            'response' => $feedbackvalue->value,
+            'response' => ($feedbackvalue->value ? $feedbackvalue->value:''),
             'completion' => $feedbackvalue->value !== '',
         ],
         'context' => [

--- a/src/transformer/events/mod_feedback/item_answered/textfield.php
+++ b/src/transformer/events/mod_feedback/item_answered/textfield.php
@@ -47,7 +47,7 @@ function textfield(array $config, \stdClass $event, \stdClass $feedbackvalue, \s
         ],
         'timestamp' => utils\get_event_timestamp($event),
         'result' => [
-            'response' => ($feedbackvalue->value ? $feedbackvalue->value:''),
+            'response' => ($feedbackvalue->value ?:''),
             'completion' => $feedbackvalue->value !== '',
         ],
         'context' => [

--- a/src/transformer/events/mod_quiz/question_answered/essay.php
+++ b/src/transformer/events/mod_quiz/question_answered/essay.php
@@ -51,7 +51,7 @@ function essay(array $config, \stdClass $event, \stdClass $questionattempt, \std
         ],
         'timestamp' => utils\get_event_timestamp($event),
         'result' => [
-            'response' => ($responsesummary ? $responsesummary:''),
+            'response' => ($responsesummary ?:''),
             'completion' => $responsesummary !== '',
         ],
         'context' => [

--- a/src/transformer/events/mod_quiz/question_answered/essay.php
+++ b/src/transformer/events/mod_quiz/question_answered/essay.php
@@ -51,7 +51,7 @@ function essay(array $config, \stdClass $event, \stdClass $questionattempt, \std
         ],
         'timestamp' => utils\get_event_timestamp($event),
         'result' => [
-            'response' => $responsesummary,
+            'response' => ($responsesummary ? $responsesummary:''),
             'completion' => $responsesummary !== '',
         ],
         'context' => [

--- a/src/transformer/events/mod_quiz/question_answered/match.php
+++ b/src/transformer/events/mod_quiz/question_answered/match.php
@@ -60,7 +60,7 @@ function match(array $config, \stdClass $event, \stdClass $questionattempt, \std
         ],
         'timestamp' => utils\get_event_timestamp($event),
         'result' => [
-            'response' => ($questionattempt->responsesummary ? $questionattempt->responsesummary:''),
+            'response' => ($questionattempt->responsesummary ?:''),
             'completion' => $questionattempt->responsesummary !== null,
             'success' => $questionattempt->rightanswer === $questionattempt->responsesummary,
             'extensions' => [

--- a/src/transformer/events/mod_quiz/question_answered/match.php
+++ b/src/transformer/events/mod_quiz/question_answered/match.php
@@ -60,7 +60,7 @@ function match(array $config, \stdClass $event, \stdClass $questionattempt, \std
         ],
         'timestamp' => utils\get_event_timestamp($event),
         'result' => [
-            'response' => $questionattempt->responsesummary,
+            'response' => ($questionattempt->responsesummary ? $questionattempt->responsesummary:''),
             'completion' => $questionattempt->responsesummary !== null,
             'success' => $questionattempt->rightanswer === $questionattempt->responsesummary,
             'extensions' => [

--- a/src/transformer/events/mod_quiz/question_answered/numerical.php
+++ b/src/transformer/events/mod_quiz/question_answered/numerical.php
@@ -49,7 +49,7 @@ function numerical(array $config, \stdClass $event, \stdClass $questionattempt, 
         ],
         'timestamp' => utils\get_event_timestamp($event),
         'result' => [
-            'response' => ($questionattempt->responsesummary ? $questionattempt->responsesummary:''),
+            'response' => ($questionattempt->responsesummary ?:''),
             'completion' => $questionattempt->responsesummary !== '',
             'success' => $questionattempt->rightanswer === $questionattempt->responsesummary,
             'extensions' => [

--- a/src/transformer/events/mod_quiz/question_answered/numerical.php
+++ b/src/transformer/events/mod_quiz/question_answered/numerical.php
@@ -49,7 +49,7 @@ function numerical(array $config, \stdClass $event, \stdClass $questionattempt, 
         ],
         'timestamp' => utils\get_event_timestamp($event),
         'result' => [
-            'response' => $questionattempt->responsesummary,
+            'response' => ($questionattempt->responsesummary ? $questionattempt->responsesummary:''),
             'completion' => $questionattempt->responsesummary !== '',
             'success' => $questionattempt->rightanswer === $questionattempt->responsesummary,
             'extensions' => [

--- a/src/transformer/events/mod_quiz/question_answered/randomsamatch.php
+++ b/src/transformer/events/mod_quiz/question_answered/randomsamatch.php
@@ -60,7 +60,7 @@ function randomsamatch(array $config, \stdClass $event, \stdClass $questionattem
         ],
         'timestamp' => utils\get_event_timestamp($event),
         'result' => [
-            'response' => $questionattempt->responsesummary,
+            'response' => ($questionattempt->responsesummary ? $questionattempt->responsesummary:''),
             'completion' => $questionattempt->responsesummary !== '',
             'success' => $questionattempt->rightanswer === $questionattempt->responsesummary,
             'extensions' => [

--- a/src/transformer/events/mod_quiz/question_answered/randomsamatch.php
+++ b/src/transformer/events/mod_quiz/question_answered/randomsamatch.php
@@ -60,7 +60,7 @@ function randomsamatch(array $config, \stdClass $event, \stdClass $questionattem
         ],
         'timestamp' => utils\get_event_timestamp($event),
         'result' => [
-            'response' => ($questionattempt->responsesummary ? $questionattempt->responsesummary:''),
+            'response' => ($questionattempt->responsesummary ?:''),
             'completion' => $questionattempt->responsesummary !== '',
             'success' => $questionattempt->rightanswer === $questionattempt->responsesummary,
             'extensions' => [

--- a/src/transformer/events/mod_quiz/question_answered/shortanswer.php
+++ b/src/transformer/events/mod_quiz/question_answered/shortanswer.php
@@ -49,7 +49,7 @@ function shortanswer(array $config, \stdClass $event, \stdClass $questionattempt
         ],
         'timestamp' => utils\get_event_timestamp($event),
         'result' => [
-            'response' => ($questionattempt->responsesummary ? $questionattempt->responsesummary:''),
+            'response' => ($questionattempt->responsesummary ?:''),
             'completion' => $questionattempt->responsesummary !== '',
         ],
         'context' => [

--- a/src/transformer/events/mod_quiz/question_answered/shortanswer.php
+++ b/src/transformer/events/mod_quiz/question_answered/shortanswer.php
@@ -49,7 +49,7 @@ function shortanswer(array $config, \stdClass $event, \stdClass $questionattempt
         ],
         'timestamp' => utils\get_event_timestamp($event),
         'result' => [
-            'response' => $questionattempt->responsesummary,
+            'response' => ($questionattempt->responsesummary ? $questionattempt->responsesummary:''),
             'completion' => $questionattempt->responsesummary !== '',
         ],
         'context' => [

--- a/src/transformer/utils/get_user.php
+++ b/src/transformer/utils/get_user.php
@@ -24,9 +24,7 @@ function get_user(array $config, \stdClass $user) {
 
     if (array_key_exists('send_mbox', $config) && $config['send_mbox'] == true && $hasvalidemail) {
         return [
-           // 'name' => $fullname,
-			'mbox_sha1sum' => sha1('mailto:' . $user->email),
-           // 'mbox' => 'mailto:' . $user->email,
+			'mbox_sha1sum' => sha1('mailto:' . $user->email)
         ];
     }
 

--- a/src/transformer/utils/get_user.php
+++ b/src/transformer/utils/get_user.php
@@ -24,8 +24,9 @@ function get_user(array $config, \stdClass $user) {
 
     if (array_key_exists('send_mbox', $config) && $config['send_mbox'] == true && $hasvalidemail) {
         return [
-            'name' => $fullname,
-            'mbox' => 'mailto:' . $user->email,
+           // 'name' => $fullname,
+			'mbox_sha1sum' => sha1('mailto:' . $user->email),
+           // 'mbox' => 'mailto:' . $user->email,
         ];
     }
 


### PR DESCRIPTION
- Applied sha1 hash to emails (CQU customisation)
- Made blank activity responses empty strings rather than NULL, as required by xAPI spec
- Prevented posts being sent to LRS with empty statement arrays
- Prevented events being logged without a user id (without an actor)
