### PR TITLE
OSI-981: Fix assignment graded and Choicegroup removed choice

### DIFF
--- a/src/transformer/events/mod_assign/assignment_graded.php
+++ b/src/transformer/events/mod_assign/assignment_graded.php
@@ -103,7 +103,7 @@ function assignment_graded(array $config, \stdClass $event) {
     }
     // Calculate scaled score as the distance from zero towards the max (or min for negative scores).
     if ($scoreraw >= 0) {
-        $statement['result']['score']['scaled'] = $scoreraw / $scoremax;
+        $statement['result']['score']['scaled'] = (float) ($scoreraw / $scoremax);
     }
 
     return [$statement];

--- a/src/transformer/events/mod_choicegroup/choice_removed.php
+++ b/src/transformer/events/mod_choicegroup/choice_removed.php
@@ -37,9 +37,9 @@ function choice_removed(array $config, \stdClass $event) {
     return [[
         'actor' => utils\get_user($config, $user),
         'verb' => [
-            'id' => 'https://w3id.org/xapi/dod-isd/verbs/removed ',
+            'id' => 'https://w3id.org/xapi/dod-isd/verbs/removed',
             'display' => [
-                $lang => 'removed '
+                $lang => 'removed'
             ],
         ],
         'object' => utils\get_activity\choicegroup($config, $event->contextinstanceid),

--- a/src/transformer/events/mod_spa/template_questions_removed.php
+++ b/src/transformer/events/mod_spa/template_questions_removed.php
@@ -36,7 +36,7 @@ function template_questions_removed(array $config, \stdClass $event) {
     return [[
         'actor' => utils\get_user($config, $user),
         'verb' => [
-            'id' => 'https://w3id.org/xapi/dod-isd/verbs/removed ',
+            'id' => 'https://w3id.org/xapi/dod-isd/verbs/removed',
             'display' => [
                 $lang => 'removed'
             ],


### PR DESCRIPTION
**Description**
- The choisegroup transformer has a wierd iri this will resolve that
- The assignment graded when scaled is pass/fail can cause a result.grade.scaled > 1 which is not allowed. Also this has to be float/decimal number

**PR Type**
- Fix
