### PR TITLE
OS-981: Fix assignment graded and choicegroup removed choice

### DIFF
--- a/src/transformer/events/mod_assign/assignment_graded.php
+++ b/src/transformer/events/mod_assign/assignment_graded.php
@@ -103,7 +103,18 @@ function assignment_graded(array $config, \stdClass $event) {
     }
     // Calculate scaled score as the distance from zero towards the max (or min for negative scores).
     if ($scoreraw >= 0) {
-        $statement['result']['score']['scaled'] = $scoreraw / $scoremax;
+        $scorescaled = $scoreraw / $scoremax;
+        if ($scorescaled < -1 || $scorescaled > 1 ) {
+            // If score scaled is outside -1 and 1 then use the final grade.
+            GLOBAL $CFG;
+            require_once($CFG->libdir.'/gradelib.php');
+            $gradinginfo = grade_get_grades($event->courseid, 'mod', 'assign', $assignment->id, $event->relateduserid);
+            if (isset($gradinginfo->items[0]) && $gradinginfo->items[0]->grades[$event->relateduserid]) {
+                $scorescaled = $gradinginfo->items[0]->grades[$event->relateduserid]->grade / $scoremax;
+            }
+        }
+
+        $statement['result']['score']['scaled'] = $scorescaled;
     }
 
     return [$statement];

--- a/src/transformer/events/mod_choicegroup/choice_removed.php
+++ b/src/transformer/events/mod_choicegroup/choice_removed.php
@@ -37,9 +37,9 @@ function choice_removed(array $config, \stdClass $event) {
     return [[
         'actor' => utils\get_user($config, $user),
         'verb' => [
-            'id' => 'https://w3id.org/xapi/dod-isd/verbs/removed ',
+            'id' => 'https://w3id.org/xapi/dod-isd/verbs/removed',
             'display' => [
-                $lang => 'removed '
+                $lang => 'removed'
             ],
         ],
         'object' => utils\get_activity\choicegroup($config, $event->contextinstanceid),

--- a/src/transformer/events/mod_spa/template_questions_removed.php
+++ b/src/transformer/events/mod_spa/template_questions_removed.php
@@ -36,7 +36,7 @@ function template_questions_removed(array $config, \stdClass $event) {
     return [[
         'actor' => utils\get_user($config, $user),
         'verb' => [
-            'id' => 'https://w3id.org/xapi/dod-isd/verbs/removed ',
+            'id' => 'https://w3id.org/xapi/dod-isd/verbs/removed',
             'display' => [
                 $lang => 'removed'
             ],


### PR DESCRIPTION
Description

- The choisegroup transformer has a wierd iri this will resolve that
- The assignment graded can cause have result.grade.scaled > 1 which is not allowed. Well use graded items instead when this happends

PR Type
 - Fix
