### PR TITLE
776 bug in mod book chapter viewed

### DIFF
--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12
+        image: postgres:13
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -30,35 +30,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - php: '7.4'
-            moodle-branch: 'MOODLE_39_STABLE'
-            database: 'pgsql'
-          - php: '7.4'
-            moodle-branch: 'MOODLE_39_STABLE'
-            database: 'mariadb'
-          - php: '7.4'
-            moodle-branch: 'MOODLE_311_STABLE'
-            database: 'pgsql'
-          - php: '7.4'
-            moodle-branch: 'MOODLE_311_STABLE'
-            database: 'mariadb'
-          - php: '8.0'
-            moodle-branch: 'MOODLE_311_STABLE'
-            database: 'pgsql'
-          - php: '8.0'
-            moodle-branch: 'MOODLE_311_STABLE'
-            database: 'mariadb'
-          - php: '8.0'
-            moodle-branch: 'MOODLE_400_STABLE'
-            database: 'pgsql'
-          - php: '8.0'
-            moodle-branch: 'MOODLE_400_STABLE'
-            database: 'mariadb'
+        php: ['8.1']
+        moodle-branch: ['MOODLE_401_STABLE', 'MOODLE_402_STABLE']
+        database: [pgsql, mariadb]
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: plugin
 
@@ -66,14 +44,15 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: ${{ matrix.extensions }}
+          extensions:
           ini-values: max_input_vars=5000
-          # none to use phpdbg fallback. Specify pcov (Moodle 3.10 and up) or xdebug to use them instead.
+          # If you are not using code coverage, keep "none". Otherwise, use "pcov" (Moodle 3.10 and up) or "xdebug".
+          # If you try to use code coverage with "none", it will fallback to phpdbg (which has known problems).
           coverage: none
 
       - name: Initialise moodle-plugin-ci
         run: |
-          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^4
           echo $(cd ci/bin; pwd) >> $GITHUB_PATH
           echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
           sudo locale-gen en_AU.UTF-8
@@ -85,14 +64,8 @@ jobs:
           cd plugin
           composer install
 
-      - name: Install additional supported plugins (Moodle 3.9-3.11)
-        if: ${{ matrix.moodle-branch == 'MOODLE_39_STABLE' || matrix.moodle-branch == 'MOODLE_310_STABLE' || matrix.moodle-branch == 'MOODLE_311_STABLE' }}
-        run: |
-          moodle-plugin-ci add-plugin --branch MOODLE_34_STABLE catalyst/moodle-mod_facetoface
-          moodle-plugin-ci add-plugin --branch v3.0-stable blindsidenetworks/moodle-mod_bigbluebuttonbn
-
       - name: Install additional supported plugins (Moodle 4.0)
-        if: ${{ matrix.moodle-branch == 'MOODLE_400_STABLE' }}
+        if: ${{ matrix.moodle-branch == 'MOODLE_401_STABLE' || matrix.moodle-branch == 'MOODLE_402_STABLE' }}
         run: |
           moodle-plugin-ci add-plugin --branch MOODLE_400_STABLE catalyst/moodle-mod_facetoface
 

--- a/src/transformer/events/mod_scorm/sco_launched.php
+++ b/src/transformer/events/mod_scorm/sco_launched.php
@@ -39,7 +39,8 @@ function sco_launched(array $config, \stdClass $event) {
     $repo = $config['repo'];
     $user = $repo->read_record_by_id('user', $event->userid);
     $course = $repo->read_record_by_id('course', $event->courseid);
-    $scorm = $repo->read_record_by_id('scorm', $event->objectid);
+    $scormscoes = $repo->read_record_by_id('scorm_scoes', $event->objectid);
+    $scorm = $repo->read_record_by_id('scorm', $scormscoes->scorm);
     $lang = utils\get_course_lang($course);
 
     return [[

--- a/src/transformer/utils/get_string_html_removed.php
+++ b/src/transformer/utils/get_string_html_removed.php
@@ -29,7 +29,7 @@ namespace src\transformer\utils;
 /**
  * Transformer utility for cleaning HTML from strings.
  *
- * @param string $string The string to clean.
+ * @param null|string $string The string to clean.
  * @return string
  */
 function get_string_html_removed(?string $string) {

--- a/src/transformer/utils/get_string_html_removed.php
+++ b/src/transformer/utils/get_string_html_removed.php
@@ -32,7 +32,10 @@ namespace src\transformer\utils;
  * @param string $string The string to clean.
  * @return string
  */
-function get_string_html_removed(string $string) {
+function get_string_html_removed(?string $string) {
+    if ($string === null) {
+        return '';
+    }
     // For some reason, newlines and &nbsp; is being added to strings.
     $replacestrings = ["\n", "&nbsp;"];
     return str_replace($replacestrings, "", strip_tags($string));

--- a/tests/core/course_completed/completing_existing_course/completing_existing_course_test.php
+++ b/tests/core/course_completed/completing_existing_course/completing_existing_course_test.php
@@ -43,6 +43,24 @@ class completing_existing_course_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "core";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "course";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_completed

--- a/tests/core/course_completed/send_jisc_data/send_jisc_data_test.php
+++ b/tests/core/course_completed/send_jisc_data/send_jisc_data_test.php
@@ -43,6 +43,24 @@ class send_jisc_data_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "core";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "jisc";
+    }
+
+    /**
      * Retrieve transformer configuration.
      *
      * @return string

--- a/tests/core/course_module_completion_update/completing_existing_module/completing_existing_module_test.php
+++ b/tests/core/course_module_completion_update/completing_existing_module/completing_existing_module_test.php
@@ -43,6 +43,24 @@ class completing_existing_module_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "core";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "course";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_module_completion_updated

--- a/tests/core/course_viewed/viewing_existing_course/viewing_existing_course_test.php
+++ b/tests/core/course_viewed/viewing_existing_course/viewing_existing_course_test.php
@@ -43,6 +43,24 @@ class viewing_existing_course_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "core";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "course";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_viewed

--- a/tests/core/user_created/existing_user_created/existing_user_created_test.php
+++ b/tests/core/user_created/existing_user_created/existing_user_created_test.php
@@ -43,6 +43,24 @@ class existing_user_created_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "core";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "user";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::user_created

--- a/tests/core/user_created/send_jisc_data/send_jisc_data_test.php
+++ b/tests/core/user_created/send_jisc_data/send_jisc_data_test.php
@@ -43,6 +43,24 @@ class send_jisc_data_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "core";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "jisc";
+    }
+
+    /**
      * Retrieve transformer configuration.
      *
      * @return void

--- a/tests/core/user_enrolment_created/existing_user_enrolled/existing_user_enrolled_test.php
+++ b/tests/core/user_enrolment_created/existing_user_enrolled/existing_user_enrolled_test.php
@@ -43,6 +43,24 @@ class existing_user_enrolled_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "core";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "user";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::user_enrolment_created

--- a/tests/core/user_loggedin/existing_user_loggedin/existing_user_loggedin_test.php
+++ b/tests/core/user_loggedin/existing_user_loggedin/existing_user_loggedin_test.php
@@ -43,6 +43,24 @@ class existing_user_loggedin_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "core";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "user";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::user_loggedin

--- a/tests/core/user_loggedout/existing_user_loggedout/existing_user_loggedout_test.php
+++ b/tests/core/user_loggedout/existing_user_loggedout/existing_user_loggedout_test.php
@@ -43,6 +43,24 @@ class existing_user_loggedout_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "core";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "user";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::user_loggedout

--- a/tests/mod_assign/assignment_graded/existing_assignment_graded_comment/existing_assignment_graded_comment_test.php
+++ b/tests/mod_assign/assignment_graded/existing_assignment_graded_comment/existing_assignment_graded_comment_test.php
@@ -43,6 +43,24 @@ class existing_assignment_graded_comment_test extends \logstore_xapi\xapi_test_c
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "assign";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::assignment_graded

--- a/tests/mod_assign/assignment_graded/existing_assignment_graded_nocomment/existing_assignment_graded_nocomment_test.php
+++ b/tests/mod_assign/assignment_graded/existing_assignment_graded_nocomment/existing_assignment_graded_nocomment_test.php
@@ -43,6 +43,24 @@ class existing_assignment_graded_nocomment_test extends \logstore_xapi\xapi_test
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "assign";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::assignment_graded

--- a/tests/mod_assign/assignment_submitted/existing_assignment_submitted/existing_assignment_submitted_test.php
+++ b/tests/mod_assign/assignment_submitted/existing_assignment_submitted/existing_assignment_submitted_test.php
@@ -43,6 +43,24 @@ class existing_assignment_submitted_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "assign";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::assignment_submitted

--- a/tests/mod_bigbluebuttonbn/activity_management_viewed/activity_management_viewed_test.php
+++ b/tests/mod_bigbluebuttonbn/activity_management_viewed/activity_management_viewed_test.php
@@ -43,6 +43,24 @@ class activity_management_viewed_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "bigbluebuttonbn";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::activity_management_viewed

--- a/tests/mod_bigbluebuttonbn/live_session/live_session_test.php
+++ b/tests/mod_bigbluebuttonbn/live_session/live_session_test.php
@@ -43,6 +43,24 @@ class live_session_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "bigbluebuttonbn";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::live_session

--- a/tests/mod_bigbluebuttonbn/meeting_created/meeting_created_test.php
+++ b/tests/mod_bigbluebuttonbn/meeting_created/meeting_created_test.php
@@ -43,6 +43,24 @@ class meeting_created_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "bigbluebuttonbn";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::meeting_created

--- a/tests/mod_bigbluebuttonbn/meeting_ended/meeting_ended_test.php
+++ b/tests/mod_bigbluebuttonbn/meeting_ended/meeting_ended_test.php
@@ -43,6 +43,24 @@ class meeting_ended_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "bigbluebuttonbn";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::meeting_ended

--- a/tests/mod_bigbluebuttonbn/meeting_joined/meeting_joined_test.php
+++ b/tests/mod_bigbluebuttonbn/meeting_joined/meeting_joined_test.php
@@ -43,6 +43,24 @@ class meeting_joined_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "bigbluebuttonbn";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::meeting_joined

--- a/tests/mod_bigbluebuttonbn/meeting_left/meeting_left_test.php
+++ b/tests/mod_bigbluebuttonbn/meeting_left/meeting_left_test.php
@@ -43,6 +43,24 @@ class meeting_left_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "bigbluebuttonbn";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::meeting_left

--- a/tests/mod_bigbluebuttonbn/recording_deleted/recording_deleted_test.php
+++ b/tests/mod_bigbluebuttonbn/recording_deleted/recording_deleted_test.php
@@ -43,6 +43,24 @@ class recording_deleted_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "bigbluebuttonbn";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::recording_deleted

--- a/tests/mod_bigbluebuttonbn/recording_edited/recording_edited_test.php
+++ b/tests/mod_bigbluebuttonbn/recording_edited/recording_edited_test.php
@@ -43,6 +43,24 @@ class recording_edited_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "bigbluebuttonbn";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::recording_edited

--- a/tests/mod_bigbluebuttonbn/recording_imported/recording_imported_test.php
+++ b/tests/mod_bigbluebuttonbn/recording_imported/recording_imported_test.php
@@ -43,6 +43,24 @@ class recording_imported_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "bigbluebuttonbn";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::recording_imported

--- a/tests/mod_bigbluebuttonbn/recording_protected/recording_protected_test.php
+++ b/tests/mod_bigbluebuttonbn/recording_protected/recording_protected_test.php
@@ -43,6 +43,24 @@ class recording_protected_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "bigbluebuttonbn";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::recording_protected

--- a/tests/mod_bigbluebuttonbn/recording_published/recording_published_test.php
+++ b/tests/mod_bigbluebuttonbn/recording_published/recording_published_test.php
@@ -43,6 +43,24 @@ class recording_published_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "bigbluebuttonbn";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::recording_published

--- a/tests/mod_bigbluebuttonbn/recording_unprotected/recording_unprotected_test.php
+++ b/tests/mod_bigbluebuttonbn/recording_unprotected/recording_unprotected_test.php
@@ -43,6 +43,24 @@ class recording_unprotected_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "bigbluebuttonbn";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::recording_unprotected

--- a/tests/mod_bigbluebuttonbn/recording_unpublished/recording_unpublished_test.php
+++ b/tests/mod_bigbluebuttonbn/recording_unpublished/recording_unpublished_test.php
@@ -43,6 +43,24 @@ class recording_unpublished_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "bigbluebuttonbn";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::recording_unpublished

--- a/tests/mod_bigbluebuttonbn/recording_viewed/recording_viewed_test.php
+++ b/tests/mod_bigbluebuttonbn/recording_viewed/recording_viewed_test.php
@@ -43,6 +43,24 @@ class recording_viewed_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "bigbluebuttonbn";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::recording_viewed

--- a/tests/mod_book/chapter_viewed/existing_chapter_viewed_with_parent/existing_chapter_viewed_with_parent_test.php
+++ b/tests/mod_book/chapter_viewed/existing_chapter_viewed_with_parent/existing_chapter_viewed_with_parent_test.php
@@ -43,6 +43,24 @@ class existing_chapter_viewed_with_parent_test extends \logstore_xapi\xapi_test_
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "book";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::chapter_viewed

--- a/tests/mod_book/chapter_viewed/existing_chapter_viewed_without_parent/existing_chapter_viewed_without_parent_test.php
+++ b/tests/mod_book/chapter_viewed/existing_chapter_viewed_without_parent/existing_chapter_viewed_without_parent_test.php
@@ -43,6 +43,24 @@ class existing_chapter_viewed_without_parent_test extends \logstore_xapi\xapi_te
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "book";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::chapter_viewed

--- a/tests/mod_book/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_book/course_module_viewed/existing_module/existing_module_test.php
@@ -43,6 +43,24 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "book";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_module_viewed

--- a/tests/mod_chat/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_chat/course_module_viewed/existing_module/existing_module_test.php
@@ -43,6 +43,24 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "chat";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_module_viewed

--- a/tests/mod_choice/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_choice/course_module_viewed/existing_module/existing_module_test.php
@@ -43,6 +43,24 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "choice";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_module_viewed

--- a/tests/mod_data/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_data/course_module_viewed/existing_module/existing_module_test.php
@@ -43,6 +43,24 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "bigbluebuttonbn";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_module_viewed

--- a/tests/mod_facetoface/cancel_booking/existing_booking_cancelled/existing_booking_canceled_test.php
+++ b/tests/mod_facetoface/cancel_booking/existing_booking_cancelled/existing_booking_canceled_test.php
@@ -43,6 +43,24 @@ class existing_booking_canceled_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "facetoface";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::cancel_booking

--- a/tests/mod_facetoface/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_facetoface/course_module_viewed/existing_module/existing_module_test.php
@@ -43,6 +43,24 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "facetoface";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_module_viewed

--- a/tests/mod_facetoface/signup_success/existing_signup_success/existing_signup_success_test.php
+++ b/tests/mod_facetoface/signup_success/existing_signup_success/existing_signup_success_test.php
@@ -43,6 +43,24 @@ class existing_signup_success_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "facetoface";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::signup_success

--- a/tests/mod_facetoface/take_attendance/existing_attendance_taken/existing_attendance_taken_test.php
+++ b/tests/mod_facetoface/take_attendance/existing_attendance_taken/existing_attendance_taken_test.php
@@ -43,6 +43,24 @@ class existing_attendance_taken_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "facetoface";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::take_attendance

--- a/tests/mod_feedback/course_module_viewed/viewing_feedback/viewing_feedback_test.php
+++ b/tests/mod_feedback/course_module_viewed/viewing_feedback/viewing_feedback_test.php
@@ -43,6 +43,24 @@ class viewing_feedback_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "feedback";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_module_viewed

--- a/tests/mod_feedback/response_submitted/multichoice/multichoice_test.php
+++ b/tests/mod_feedback/response_submitted/multichoice/multichoice_test.php
@@ -43,6 +43,24 @@ class multichoice_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "feedback";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::response_submitted

--- a/tests/mod_feedback/response_submitted/multichoicerated/multichoicerated_test.php
+++ b/tests/mod_feedback/response_submitted/multichoicerated/multichoicerated_test.php
@@ -43,6 +43,24 @@ class multichoicerated_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "feedback";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::response_submitted

--- a/tests/mod_feedback/response_submitted/no_items/no_items_test.php
+++ b/tests/mod_feedback/response_submitted/no_items/no_items_test.php
@@ -43,6 +43,24 @@ class no_items_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "feedback";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::response_submitted

--- a/tests/mod_feedback/response_submitted/numerical/numerical_test.php
+++ b/tests/mod_feedback/response_submitted/numerical/numerical_test.php
@@ -43,6 +43,24 @@ class numerical_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "feedback";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::response_submitted

--- a/tests/mod_feedback/response_submitted/textarea/textarea_test.php
+++ b/tests/mod_feedback/response_submitted/textarea/textarea_test.php
@@ -43,6 +43,24 @@ class textarea_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "feedback";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::response_submitted

--- a/tests/mod_feedback/response_submitted/textfield/textfield_test.php
+++ b/tests/mod_feedback/response_submitted/textfield/textfield_test.php
@@ -43,6 +43,24 @@ class textfield_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "feedback";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::response_submitted

--- a/tests/mod_feedback/response_submitted/unknown_typ/unknown_typ_test.php
+++ b/tests/mod_feedback/response_submitted/unknown_typ/unknown_typ_test.php
@@ -43,6 +43,24 @@ class unknown_typ_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "feedback";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::response_submitted

--- a/tests/mod_folder/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_folder/course_module_viewed/existing_module/existing_module_test.php
@@ -43,6 +43,24 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "folder";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_module_viewed

--- a/tests/mod_forum/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_forum/course_module_viewed/existing_module/existing_module_test.php
@@ -43,6 +43,24 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "forum";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_module_viewed

--- a/tests/mod_forum/discussion_created/existing_module_test.php
+++ b/tests/mod_forum/discussion_created/existing_module_test.php
@@ -43,6 +43,24 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "forum";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::discussion_created

--- a/tests/mod_forum/discussion_viewed/existing_discussion_viewed/existing_discussion_viewed_test.php
+++ b/tests/mod_forum/discussion_viewed/existing_discussion_viewed/existing_discussion_viewed_test.php
@@ -43,6 +43,24 @@ class existing_discussion_viewed_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "forum";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::discussion_viewed

--- a/tests/mod_forum/post_created/post_created_test.php
+++ b/tests/mod_forum/post_created/post_created_test.php
@@ -43,6 +43,24 @@ class post_created_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "forum";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::post_created

--- a/tests/mod_forum/user_report_viewed/existing_report_viewed/existing_report_viewed_test.php
+++ b/tests/mod_forum/user_report_viewed/existing_report_viewed/existing_report_viewed_test.php
@@ -43,6 +43,24 @@ class existing_report_viewed_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "forum";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::user_report_viewed

--- a/tests/mod_forum/user_report_viewed/existing_report_viewed_all_courses/existing_report_viewed_all_courses_test.php
+++ b/tests/mod_forum/user_report_viewed/existing_report_viewed_all_courses/existing_report_viewed_all_courses_test.php
@@ -43,6 +43,24 @@ class existing_report_viewed_all_courses_test extends \logstore_xapi\xapi_test_c
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "forum";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::user_report_viewed

--- a/tests/mod_glossary/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_glossary/course_module_viewed/existing_module/existing_module_test.php
@@ -43,6 +43,24 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "glossary";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_module_viewed

--- a/tests/mod_imscp/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_imscp/course_module_viewed/existing_module/existing_module_test.php
@@ -43,6 +43,24 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "imscp";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_module_viewed

--- a/tests/mod_lesson/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_lesson/course_module_viewed/existing_module/existing_module_test.php
@@ -43,6 +43,24 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "lesson";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_module_viewed

--- a/tests/mod_lti/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_lti/course_module_viewed/existing_module/existing_module_test.php
@@ -43,6 +43,24 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "lti";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_module_viewed

--- a/tests/mod_page/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_page/course_module_viewed/existing_module/existing_module_test.php
@@ -43,6 +43,24 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "page";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_module_viewed

--- a/tests/mod_quiz/attempt_reviewed/existing_attempt_reviewed/existing_attempt_reviewed_test.php
+++ b/tests/mod_quiz/attempt_reviewed/existing_attempt_reviewed/existing_attempt_reviewed_test.php
@@ -43,6 +43,24 @@ class existing_attempt_reviewed_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "quiz";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::attempt_reviewed

--- a/tests/mod_quiz/attempt_started/existing_attempt_started/existing_attempt_started_test.php
+++ b/tests/mod_quiz/attempt_started/existing_attempt_started/existing_attempt_started_test.php
@@ -43,6 +43,24 @@ class existing_attempt_started_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "quiz";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::attempt_started

--- a/tests/mod_quiz/attempt_submitted/essay/essay_test.php
+++ b/tests/mod_quiz/attempt_submitted/essay/essay_test.php
@@ -43,6 +43,24 @@ class essay_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "quiz";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::attempt_submitted

--- a/tests/mod_quiz/attempt_submitted/essay_null_response/essay_null_response_test.php
+++ b/tests/mod_quiz/attempt_submitted/essay_null_response/essay_null_response_test.php
@@ -43,6 +43,24 @@ class essay_null_response_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "quiz";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::attempt_submitted

--- a/tests/mod_quiz/attempt_submitted/gapselect/gapselect_test.php
+++ b/tests/mod_quiz/attempt_submitted/gapselect/gapselect_test.php
@@ -43,6 +43,24 @@ class gapselect_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "quiz";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::attempt_submitted

--- a/tests/mod_quiz/attempt_submitted/match/match_test.php
+++ b/tests/mod_quiz/attempt_submitted/match/match_test.php
@@ -43,6 +43,24 @@ class match_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "quiz";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::attempt_submitted

--- a/tests/mod_quiz/attempt_submitted/multichoice/multichoice_test.php
+++ b/tests/mod_quiz/attempt_submitted/multichoice/multichoice_test.php
@@ -43,6 +43,24 @@ class multichoice_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "quiz";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::attempt_submitted

--- a/tests/mod_quiz/attempt_submitted/multichoice_withchoices/multichoice_withchoices_test.php
+++ b/tests/mod_quiz/attempt_submitted/multichoice_withchoices/multichoice_withchoices_test.php
@@ -43,6 +43,24 @@ class multichoice_withchoices_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "quiz";
+    }
+
+    /**
      * Retrieve the transformer configuration.
      *
      * @return string

--- a/tests/mod_quiz/attempt_submitted/multichoiceset/multichoiceset_test.php
+++ b/tests/mod_quiz/attempt_submitted/multichoiceset/multichoiceset_test.php
@@ -43,6 +43,24 @@ class multichoiceset_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "quiz";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::attempt_submitted

--- a/tests/mod_quiz/attempt_submitted/multichoiceset_withchoices/multichoiceset_withchoices_test.php
+++ b/tests/mod_quiz/attempt_submitted/multichoiceset_withchoices/multichoiceset_withchoices_test.php
@@ -43,6 +43,24 @@ class multichoiceset_withchoices_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "quiz";
+    }
+
+    /**
      * Retrieve transformer configuration.
      *
      * @return string

--- a/tests/mod_quiz/attempt_submitted/no_questions/no_questions_test.php
+++ b/tests/mod_quiz/attempt_submitted/no_questions/no_questions_test.php
@@ -43,6 +43,24 @@ class no_questions_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "quiz";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::attempt_submitted

--- a/tests/mod_quiz/attempt_submitted/numerical/numerical_test.php
+++ b/tests/mod_quiz/attempt_submitted/numerical/numerical_test.php
@@ -43,6 +43,24 @@ class numerical_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "quiz";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::attempt_submitted

--- a/tests/mod_quiz/attempt_submitted/randomsamatch/randomsamatch_test.php
+++ b/tests/mod_quiz/attempt_submitted/randomsamatch/randomsamatch_test.php
@@ -43,6 +43,24 @@ class randomsamatch_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "quiz";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::attempt_submitted

--- a/tests/mod_quiz/attempt_submitted/shortanswer/shortanswer_test.php
+++ b/tests/mod_quiz/attempt_submitted/shortanswer/shortanswer_test.php
@@ -43,6 +43,24 @@ class shortanswer_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "quiz";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::attempt_submitted

--- a/tests/mod_quiz/attempt_submitted/truefalse/truefalse_test.php
+++ b/tests/mod_quiz/attempt_submitted/truefalse/truefalse_test.php
@@ -43,6 +43,24 @@ class truefalse_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "quiz";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::attempt_submitted

--- a/tests/mod_quiz/attempt_submitted/unknown_qtype/unknown_qtype_test.php
+++ b/tests/mod_quiz/attempt_submitted/unknown_qtype/unknown_qtype_test.php
@@ -43,6 +43,24 @@ class unknown_qtype_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "quiz";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::attempt_submitted

--- a/tests/mod_quiz/attempt_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_quiz/attempt_viewed/existing_module/existing_module_test.php
@@ -43,6 +43,24 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "quiz";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::attempt_viewed

--- a/tests/mod_quiz/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_quiz/course_module_viewed/existing_module/existing_module_test.php
@@ -43,6 +43,24 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "quiz";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_module_viewed

--- a/tests/mod_resource/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_resource/course_module_viewed/existing_module/existing_module_test.php
@@ -43,6 +43,24 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "resource";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_module_viewed

--- a/tests/mod_scorm/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_scorm/course_module_viewed/existing_module/existing_module_test.php
@@ -43,6 +43,24 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "scorm";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_module_viewed

--- a/tests/mod_scorm/sco_launched/existing_sco_launched/existing_sco_launched_test.php
+++ b/tests/mod_scorm/sco_launched/existing_sco_launched/existing_sco_launched_test.php
@@ -43,6 +43,24 @@ class existing_sco_launched_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "scorm";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::sco_launched

--- a/tests/mod_scorm/scoreraw_submitted/existing_scoreraw_submitted/existing_scoreraw_submitted_test.php
+++ b/tests/mod_scorm/scoreraw_submitted/existing_scoreraw_submitted/existing_scoreraw_submitted_test.php
@@ -43,6 +43,24 @@ class existing_scoreraw_submitted_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "scorm";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::scoreraw_submitted

--- a/tests/mod_scorm/status_submitted/existing_status_submitted/existing_status_submitted_test.php
+++ b/tests/mod_scorm/status_submitted/existing_status_submitted/existing_status_submitted_test.php
@@ -43,6 +43,24 @@ class existing_status_submitted_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "scorm";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::status_submitted

--- a/tests/mod_survey/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_survey/course_module_viewed/existing_module/existing_module_test.php
@@ -43,6 +43,24 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "survey";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_module_viewed

--- a/tests/mod_url/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_url/course_module_viewed/existing_module/existing_module_test.php
@@ -43,6 +43,24 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "url";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_module_viewed

--- a/tests/mod_wiki/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_wiki/course_module_viewed/existing_module/existing_module_test.php
@@ -43,6 +43,24 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "wiki";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_module_viewed

--- a/tests/mod_workshop/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_workshop/course_module_viewed/existing_module/existing_module_test.php
@@ -43,6 +43,24 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
     }
 
     /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "mod";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "workshop";
+    }
+
+    /**
      * Appease auto-detecting of test cases. xapi_test_case has default test cases.
      *
      * @covers ::course_module_viewed

--- a/tests/totara_program/program_assigned/existing_program/test.php
+++ b/tests/totara_program/program_assigned/existing_program/test.php
@@ -35,4 +35,22 @@ class test extends \logstore_xapi\xapi_test_case {
     protected function get_test_dir() {
         return __DIR__;
     }
+
+    /**
+     * Retrieve the plugin type being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_type() {
+        return "totara";
+    }
+
+    /**
+     * Retrieve the plugin name being tested.
+     *
+     * @return string
+     */
+    protected function get_plugin_name() {
+        return "program";
+    }
 }

--- a/tests/xapi_test_case.php
+++ b/tests/xapi_test_case.php
@@ -42,6 +42,16 @@ abstract class xapi_test_case extends \advanced_testcase {
     abstract protected function get_test_dir();
 
     /**
+     * Retrieve the plugin type being tested.
+     */
+    abstract protected function get_plugin_type();
+
+    /**
+     * Retrieve the plugin name being tested.
+     */
+    abstract protected function get_plugin_name();
+
+    /**
      * Retrieve the test data from data.json.
      *
      * @return object
@@ -151,8 +161,18 @@ abstract class xapi_test_case extends \advanced_testcase {
      * @return void
      */
     private function assert_expected_statements(array $statements) {
-        $expectedstatements = $this->get_expected_statements();
-        $actualstatements = json_encode($statements, JSON_PRETTY_PRINT);
-        $this->assertEquals($expectedstatements, $actualstatements);
+
+        // Skip the test if the plugin is not installed.
+        $pluginname = $this->get_plugin_name();
+        $plugintype = $this->get_plugin_type();
+        $plugins = \core_plugin_manager::instance()->get_installed_plugins($plugintype);
+
+        if (array_key_exists($pluginname, $plugins) || $plugintype == 'core') {
+            $expectedstatements = $this->get_expected_statements();
+            $actualstatements = json_encode($statements, JSON_PRETTY_PRINT);
+            $this->assertEquals($expectedstatements, $actualstatements);
+        } else {
+            $this->markTestSkipped('Plugin ' . $pluginname . ' not installed, skipping');
+        }
     }
 }


### PR DESCRIPTION
**Description**
- Pulls in upstream fixes.
- The `\mod_book\event\chapter_viewed` event for module `mod_book` was fetching a parent chapter incorrectly. Before subchapter was used as a ID, which is actually a boolean value. Here is a representation of what it should look like, and should help understand the code.  Also the upstream merge request is here: https://github.com/xAPI-vle/moodle-logstore_xapi/pull/849
```
 SELECT id, bookid, pagenum, subchapter, title FROM mdl_book_chapters ORDER BY pagenum;                  
 id | bookid | pagenum | subchapter |         title         
----+--------+---------+------------+-----------------------
  1 |      1 |       1 |          0 | Chapter 1
  2 |      1 |       2 |          1 | Chapter 1.1
  3 |      1 |       3 |          1 | Chapter 1.2
  4 |      1 |       4 |          1 | Chapter 1.3
  6 |      1 |       5 |          1 | Chapter 1.4 (was 2.1)
  5 |      1 |       6 |          0 | Chapter 2
(6 rows)
```

**Related Issues**
- #776
- #686
- #845
- #839

**PR Type**
- Fix and improvements
