### PR TITLE
776 bug in mod book chapter viewed

### DIFF
--- a/src/transformer/repos/TestRepository.php
+++ b/src/transformer/repos/TestRepository.php
@@ -54,11 +54,20 @@ class TestRepository extends Repository {
         $matchingrecords = [];
 
         foreach ($records as $record) {
+            $conditionfailed = false;
+
             foreach ($query as $key => $value) {
-                if ($record->$key === $value) {
-                    $matchingrecords[] = (object) $record;
+                if ($record->$key !== $value) {
+                    $conditionfailed = true;
+                    break;
                 }
             }
+
+            if ($conditionfailed) {
+                continue;
+            }
+
+            $matchingrecords[] = (object) $record;
         }
 
         return $matchingrecords;


### PR DESCRIPTION
**Description**
- The `\mod_book\event\chapter_viewed` event for module `mod_book` was fetching a parent chapter incorrectly. Before subchapter was used as a ID, which is actually a boolean value. Here is a representation of what it should look like, and should help understand the code.  Also the upstream merge request is here: https://github.com/xAPI-vle/moodle-logstore_xapi/pull/849
```
 SELECT id, bookid, pagenum, subchapter, title FROM mdl_book_chapters ORDER BY pagenum;                  
 id | bookid | pagenum | subchapter |         title         
----+--------+---------+------------+-----------------------
  1 |      1 |       1 |          0 | Chapter 1
  2 |      1 |       2 |          1 | Chapter 1.1
  3 |      1 |       3 |          1 | Chapter 1.2
  4 |      1 |       4 |          1 | Chapter 1.3
  6 |      1 |       5 |          1 | Chapter 1.4 (was 2.1)
  5 |      1 |       6 |          0 | Chapter 2
(6 rows)
```

**Related Issues**
- #776
- #850

**PR Type**
- Fix and improvements
