### PR TITLE
Resolve deprecated error passing null to string parameter

### DIFF
--- a/classes/admin/admin_setting_userselection.php
+++ b/classes/admin/admin_setting_userselection.php
@@ -41,7 +41,12 @@ class admin_setting_userselection extends \admin_setting {
      * @return array The ids of the currently selected users.
      */
     public function get_setting() {
-        return explode(',', $this->config_read($this->name));
+        $setting = $this->config_read($this->name);
+        if (!$setting) {
+            return [];
+        }
+
+        return explode(',', $setting);
     }
 
     /**


### PR DESCRIPTION
Resolves: 

```
Deprecated: explode(): Passing null to parameter #2 ($string) of type string is deprecated in /var/www/vanilla-403/admin/tool/log/store/xapi/classes/admin/admin_setting_userselection.php on line 44
```