### PR TITLE
Revert "OS-1095: Add fixes to skeleton work with 4.1"

### DIFF
--- a/tests/enchancement_jisc_skeleton.php
+++ b/tests/enchancement_jisc_skeleton.php
@@ -74,34 +74,11 @@ abstract class enchancement_jisc_skeleton extends \advanced_testcase {
             return;
         }
 
-        /**
-         * In src/transformer/get_event_function_map.php we created a fix for core_event_deprecated_testcase. This causes the
-         * xapi_test_case to fail. The fix for WR322566 constant is applied to non xapi_test_case tests.
-         */
-        if (!isset($GLOBALS['PHPUNIT_XAPI_TESTCASE'])) {
-            // We use a mutable global.
-            $GLOBALS['PHPUNIT_XAPI_TESTCASE'] = true;
-        }
-
         // From Moodle 3.9 an extra event has been added.
         if ($version >= 2020061500) {
             $this->generatedhistorylog = 12;
             $this->generatedxapilog = 2;
         }
-
-        // From Moodle 4.1 is just one.
-        if ($version >= 2022112800) {
-            $this->generatedxapilog = 1;
-        }
-    }
-
-    /**
-     * Remove anything done in the setup.
-     *
-     * @return void
-     */
-    protected function tearDown(): void {
-        unset($GLOBALS['PHPUNIT_XAPI_TESTCASE']);
     }
 
     /**


### PR DESCRIPTION
This reverts commit 683f156bbf6b9baa9ec089fc75023d92167a3eb4 fixing the unit test. 

<details>
<summary>PHPUnit test run results Before</summary>

```
Moodle 4.3.2 (Build: 20231222), abd37ea768a90bf6424507b93d4ea3690e86580e
Php: 8.1.24, pgsql: 14.0 (Debian 14.0-1.pgdg110+1), OS: Linux 6.4.12-060412-generic x86_64
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

..................FFFFFF.......................................  63 / 167 ( 37%)
............................................................... 126 / 167 ( 75%)
......................................FFF                       167 / 167 (100%)

Time: 03:32.355, Memory: 102.50 MB

There were 9 failures:

1) logstore_xapi\failed_report_test::test_single_element
Failed asserting that actual size 2 matches expected size 1.

/var/www/he-43/admin/tool/log/store/xapi/tests/enchancement_jisc_skeleton.php:122
/var/www/he-43/admin/tool/log/store/xapi/tests/enchancement_jisc_skeleton.php:270
/var/www/he-43/admin/tool/log/store/xapi/tests/failed_report_test.php:80
/var/www/he-43/lib/phpunit/classes/advanced_testcase.php:81

2) logstore_xapi\failed_report_test::test_multiple_elements
Failed asserting that actual size 10 matches expected size 5.

/var/www/he-43/admin/tool/log/store/xapi/tests/enchancement_jisc_skeleton.php:122
/var/www/he-43/admin/tool/log/store/xapi/tests/enchancement_jisc_skeleton.php:306
/var/www/he-43/admin/tool/log/store/xapi/tests/failed_report_test.php:101
/var/www/he-43/lib/phpunit/classes/advanced_testcase.php:81

3) logstore_xapi\failed_report_test::test_general
Failed asserting that actual size 2 matches expected size 1.

/var/www/he-43/admin/tool/log/store/xapi/tests/enchancement_jisc_skeleton.php:122
/var/www/he-43/admin/tool/log/store/xapi/tests/enchancement_jisc_skeleton.php:249
/var/www/he-43/lib/phpunit/classes/advanced_testcase.php:81

4) logstore_xapi\history_report_test::test_single_element
Failed asserting that actual size 2 matches expected size 1.

/var/www/he-43/admin/tool/log/store/xapi/tests/enchancement_jisc_skeleton.php:122
/var/www/he-43/admin/tool/log/store/xapi/tests/enchancement_jisc_skeleton.php:270
/var/www/he-43/admin/tool/log/store/xapi/tests/history_report_test.php:78
/var/www/he-43/lib/phpunit/classes/advanced_testcase.php:81

5) logstore_xapi\history_report_test::test_multiple_elements
Failed asserting that actual size 10 matches expected size 5.

/var/www/he-43/admin/tool/log/store/xapi/tests/enchancement_jisc_skeleton.php:122
/var/www/he-43/admin/tool/log/store/xapi/tests/enchancement_jisc_skeleton.php:306
/var/www/he-43/admin/tool/log/store/xapi/tests/history_report_test.php:99
/var/www/he-43/lib/phpunit/classes/advanced_testcase.php:81

6) logstore_xapi\history_report_test::test_general
Failed asserting that actual size 2 matches expected size 1.

/var/www/he-43/admin/tool/log/store/xapi/tests/enchancement_jisc_skeleton.php:122
/var/www/he-43/admin/tool/log/store/xapi/tests/enchancement_jisc_skeleton.php:249
/var/www/he-43/lib/phpunit/classes/advanced_testcase.php:81

7) logstore_xapi\moveback_failed_statements_test::test_single_element
Failed asserting that actual size 2 matches expected size 1.

/var/www/he-43/admin/tool/log/store/xapi/tests/enchancement_jisc_skeleton.php:122
/var/www/he-43/admin/tool/log/store/xapi/tests/enchancement_jisc_skeleton.php:270
/var/www/he-43/admin/tool/log/store/xapi/tests/moveback_failed_statements_test.php:46
/var/www/he-43/lib/phpunit/classes/advanced_testcase.php:81

8) logstore_xapi\moveback_failed_statements_test::test_multiple_elements
Failed asserting that actual size 10 matches expected size 5.

/var/www/he-43/admin/tool/log/store/xapi/tests/enchancement_jisc_skeleton.php:122
/var/www/he-43/admin/tool/log/store/xapi/tests/enchancement_jisc_skeleton.php:306
/var/www/he-43/admin/tool/log/store/xapi/tests/moveback_failed_statements_test.php:73
/var/www/he-43/lib/phpunit/classes/advanced_testcase.php:81

9) logstore_xapi\moveback_failed_statements_test::test_general
Failed asserting that actual size 2 matches expected size 1.

/var/www/he-43/admin/tool/log/store/xapi/tests/enchancement_jisc_skeleton.php:122
/var/www/he-43/admin/tool/log/store/xapi/tests/enchancement_jisc_skeleton.php:249
/var/www/he-43/lib/phpunit/classes/advanced_testcase.php:81

FAILURES!
Tests: 167, Assertions: 304, Failures: 9.
```
</details>

PHPUnit test run results After

```
Moodle 4.3.2 (Build: 20231222), abd37ea768a90bf6424507b93d4ea3690e86580e
Php: 8.1.24, pgsql: 14.0 (Debian 14.0-1.pgdg110+1), OS: Linux 6.4.12-060412-generic x86_64
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

...............................................................  63 / 167 ( 37%)
............................................................... 126 / 167 ( 75%)
.........................................                       167 / 167 (100%)

Time: 03:06.313, Memory: 106.50 MB

OK (167 tests, 406 assertions)
```